### PR TITLE
F: send_and_recv_with_timeout method added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "xan-actor"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "async-trait",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xan-actor"
-version = "10.0.0"
+version = "10.1.0"
 edition = "2024"
 authors = [ "Xanthorrhizol <xanthorrhizol@proton.me>" ]
 description = "Akka actor"

--- a/src/actor_system.rs
+++ b/src/actor_system.rs
@@ -1225,6 +1225,9 @@ impl ActorSystem {
     /// For cross-node calls the dispatcher's pending-requests entry is
     /// reclaimed via a `Drop` guard, so a late-arriving response is
     /// silently discarded rather than leaking.
+    ///
+    /// Takes `&mut self` (unlike the `_without_tx_cache` variant) because
+    /// the wrapped `send_and_recv` mutates the per-clone TX cache.
     pub async fn send_and_recv_with_timeout<T>(
         &mut self,
         #[cfg(not(feature = "multi-node"))] address: String,

--- a/src/actor_system.rs
+++ b/src/actor_system.rs
@@ -1210,6 +1210,66 @@ impl ActorSystem {
         }
     }
 
+    /// `send_and_recv` with a wall-clock deadline. Returns
+    /// [`ActorError::Timeout`] if the reply doesn't arrive within
+    /// `timeout`.
+    ///
+    /// Useful under `multi-node` where a dead peer would otherwise leave
+    /// the call awaiting a response that will never arrive — the
+    /// underlying `oneshot` waiter can only fire when the remote sends a
+    /// response back, so there's no implicit failure detection on the
+    /// network path. Applies to the local path too: a slow `handle`
+    /// implementation gets cut off the same way.
+    ///
+    /// Cancellation: when `timeout` fires the inner future is dropped.
+    /// For cross-node calls the dispatcher's pending-requests entry is
+    /// reclaimed via a `Drop` guard, so a late-arriving response is
+    /// silently discarded rather than leaking.
+    pub async fn send_and_recv_with_timeout<T>(
+        &mut self,
+        #[cfg(not(feature = "multi-node"))] address: String,
+        #[cfg(feature = "multi-node")] address: crate::inter_node::Address,
+        msg: <T as Actor>::Message,
+        timeout: std::time::Duration,
+    ) -> Result<<T as Actor>::Result, ActorError>
+    where
+        T: Actor,
+        <T as Actor>::Message: MaybeCodec,
+        <T as Actor>::Result: MaybeCodec,
+    {
+        match tokio::time::timeout(timeout, self.send_and_recv::<T>(address, msg)).await {
+            Ok(result) => result,
+            Err(_) => Err(ActorError::Timeout(timeout)),
+        }
+    }
+
+    /// Cache-bypassing variant of [`send_and_recv_with_timeout`]. Same
+    /// timeout semantics; same cleanup on the cross-node path.
+    ///
+    /// [`send_and_recv_with_timeout`]: Self::send_and_recv_with_timeout
+    pub async fn send_and_recv_without_tx_cache_with_timeout<T>(
+        &self,
+        #[cfg(not(feature = "multi-node"))] address: String,
+        #[cfg(feature = "multi-node")] address: crate::inter_node::Address,
+        msg: <T as Actor>::Message,
+        timeout: std::time::Duration,
+    ) -> Result<<T as Actor>::Result, ActorError>
+    where
+        T: Actor,
+        <T as Actor>::Message: MaybeCodec,
+        <T as Actor>::Result: MaybeCodec,
+    {
+        match tokio::time::timeout(
+            timeout,
+            self.send_and_recv_without_tx_cache::<T>(address, msg),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(ActorError::Timeout(timeout)),
+        }
+    }
+
     /// Spawn a background job that delivers `msg` to `address` on the
     /// schedule described by [`JobSpec`].
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,10 +22,15 @@ pub enum ActorError {
     /// variant for both backends.
     #[error("Failed to recv from channel")]
     ChannelRecv,
-    /// A timed `send_and_recv` (via `ActorSystem::with_timeout`) did not
-    /// receive its reply within the configured duration. Common cause in
-    /// multi-node mode: the remote peer died or the broker dropped the
-    /// in-flight request.
+    /// A timed `send_and_recv` (via
+    /// [`ActorSystem::send_and_recv_with_timeout`] or
+    /// [`ActorSystem::send_and_recv_without_tx_cache_with_timeout`]) did
+    /// not receive its reply within the configured duration. Common
+    /// cause in multi-node mode: the remote peer died or the broker
+    /// dropped the in-flight request.
+    ///
+    /// [`ActorSystem::send_and_recv_with_timeout`]: crate::ActorSystem::send_and_recv_with_timeout
+    /// [`ActorSystem::send_and_recv_without_tx_cache_with_timeout`]: crate::ActorSystem::send_and_recv_without_tx_cache_with_timeout
     #[error("Operation timed out after {0:?}")]
     Timeout(std::time::Duration),
     /// `address_regex` failed to compile (broadcast / restart / unregister).

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,12 @@ pub enum ActorError {
     /// variant for both backends.
     #[error("Failed to recv from channel")]
     ChannelRecv,
+    /// A timed `send_and_recv` (via `ActorSystem::with_timeout`) did not
+    /// receive its reply within the configured duration. Common cause in
+    /// multi-node mode: the remote peer died or the broker dropped the
+    /// in-flight request.
+    #[error("Operation timed out after {0:?}")]
+    Timeout(std::time::Duration),
     /// `address_regex` failed to compile (broadcast / restart / unregister).
     #[error(transparent)]
     AddressRegexError(#[from] regex::Error),

--- a/src/inter_node/dispatcher.rs
+++ b/src/inter_node/dispatcher.rs
@@ -122,6 +122,13 @@ impl InterNodeRuntime {
                 .map_err(|_| ActorError::InterNodeRemote("pending map poisoned".into()))?;
             map.insert(req_id, tx);
         }
+        // From here on the pending entry must be cleaned up if we exit
+        // before `rx.await` completes — including when the outer
+        // `send_and_recv_with_timeout` cancels this future.
+        let _guard = PendingGuard {
+            pending: self.pending.clone(),
+            req_id,
+        };
         let envelope = InterNodeMessage::Call {
             actor_type: actor_type.to_string(),
             target_name: target.name.clone(),
@@ -134,9 +141,6 @@ impl InterNodeRuntime {
             .produce(&Topic::request(&target.node), envelope)
             .await
         {
-            if let Ok(mut map) = self.pending.lock() {
-                map.remove(&req_id);
-            }
             return Err(ActorError::InterNodeIo(e.to_string()));
         }
         let outcome = rx
@@ -248,6 +252,25 @@ impl InterNodeRuntime {
         });
 
         Ok(())
+    }
+}
+
+/// RAII cleanup for an entry in [`InterNodeRuntime`]'s pending-requests
+/// map. Drops the entry on scope exit whether the call returned an error,
+/// the response arrived, or the awaiting future was cancelled (e.g. by
+/// `send_and_recv_with_timeout`). Without this, a cancelled call would
+/// leave a dangling `req_id → Sender` entry that only gets reclaimed if
+/// the peer eventually replies.
+struct PendingGuard {
+    pending: PendingMap,
+    req_id: u64,
+}
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.pending.lock() {
+            map.remove(&self.req_id);
+        }
     }
 }
 

--- a/src/inter_node/dispatcher.rs
+++ b/src/inter_node/dispatcher.rs
@@ -115,19 +115,21 @@ impl InterNodeRuntime {
     ) -> Result<Vec<u8>, ActorError> {
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = oneshot::channel();
-        {
+        // Insert and arm the cleanup guard in the same locked region so
+        // there's no window in which the entry could survive a panic or
+        // early return without the `Drop` reclaiming it. The guard
+        // handles every exit path from here on — return-on-error,
+        // return-on-response, and cancel-by-timeout.
+        let _guard = {
             let mut map = self
                 .pending
                 .lock()
                 .map_err(|_| ActorError::InterNodeRemote("pending map poisoned".into()))?;
             map.insert(req_id, tx);
-        }
-        // From here on the pending entry must be cleaned up if we exit
-        // before `rx.await` completes — including when the outer
-        // `send_and_recv_with_timeout` cancels this future.
-        let _guard = PendingGuard {
-            pending: self.pending.clone(),
-            req_id,
+            PendingGuard {
+                pending: self.pending.clone(),
+                req_id,
+            }
         };
         let envelope = InterNodeMessage::Call {
             actor_type: actor_type.to_string(),

--- a/src/test/test_single_node.rs
+++ b/src/test/test_single_node.rs
@@ -578,3 +578,69 @@ async fn test_bench_without_tx_cache() {
     info!("kill and unregister actor *");
     actor_system.unregister("*".to_string() /* address as regex */);
 }
+
+struct SlowActor {
+    pub address: String,
+}
+
+#[async_trait::async_trait]
+impl Actor for SlowActor {
+    type Message = MyMessage1;
+    type Result = MyMessage1;
+    type Error = MyError;
+
+    fn address(&self) -> &str {
+        &self.address
+    }
+
+    async fn handle(
+        &mut self,
+        msg: Arc<Self::Message>,
+    ) -> Result<Self::Result, Self::Error> {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        Ok((*msg).clone())
+    }
+}
+
+#[tokio::test]
+async fn test_send_and_recv_with_timeout_fires() {
+    init_logger();
+    let mut actor_system = make_system().await;
+
+    let actor = SlowActor {
+        address: "/slow/1".to_string(),
+    };
+    let _ = actor
+        .register(
+            &mut actor_system,
+            ErrorHandling::Stop,
+            Blocking::NonBlocking,
+            None,
+        )
+        .await;
+
+    let deadline = std::time::Duration::from_millis(100);
+    let started = std::time::Instant::now();
+    let result = actor_system
+        .send_and_recv_with_timeout::<SlowActor>(
+            "/slow/1".to_string(),
+            MyMessage1::A("hi".to_string()),
+            deadline,
+        )
+        .await;
+    let elapsed = started.elapsed();
+
+    match result {
+        Err(ActorError::Timeout(d)) => assert_eq!(d, deadline),
+        other => panic!("expected Timeout, got {:?}", other),
+    }
+    // Should return promptly when the deadline fires, not wait out the 5s
+    // handler. Allow some slack for scheduling.
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "timeout took too long: {:?}",
+        elapsed
+    );
+
+    actor_system.unregister("*".to_string());
+}


### PR DESCRIPTION
## Summary

  Adds a configurable timeout to `send_and_recv`. Without it, a `send_and_recv`
  that targets a dead multi-node peer (or a permanently stuck local handler)
  parks forever on its `oneshot` waiter — the local single-node path detects
  handler crashes via `Sender` drop, but the cross-node path has no equivalent
  signal.

  Two new methods on `ActorSystem`:

  - `send_and_recv_with_timeout::<T>(addr, msg, timeout) -> Result<T::Result, ActorError>`
  - `send_and_recv_without_tx_cache_with_timeout::<T>(addr, msg, timeout)`

  Both wrap the existing `send_and_recv` family with `tokio::time::timeout`,
  so the deadline applies uniformly to local and cross-node calls. On
  expiry they return `ActorError::Timeout(Duration)` (new variant).

  ### Pending-map cleanup on cancel

  When the outer timeout fires, the inner `send_and_recv` future is dropped
  mid-`rx.await`. For the cross-node path that previously left a dangling
  `req_id → Sender` entry in `InterNodeRuntime`'s pending-requests map,
  only reclaimed if the peer eventually replied — a slow leak on every
  timed-out call against an unresponsive peer.

  `InterNodeRuntime::call` now scopes the entry under a `PendingGuard`
  RAII type whose `Drop` removes it, covering the return-on-error,
  return-on-response, and cancel-by-timeout paths uniformly. The
  previously-manual cleanup on `produce` failure folds into the same guard.

  ## Usage

  ```rust
  use std::time::Duration;
  use xan_actor::ActorError;

  let result = system
      .send_and_recv_with_timeout::<MyActor>(addr, msg, Duration::from_secs(3))
      .await;
  match result {
      Ok(r) => /* reply received */,
      Err(ActorError::Timeout(d)) => /* no reply within d */,
      Err(e) => /* other error: AddressNotFound, InterNodeRemote, ... */,
  }

  API design choice

  Considered a builder (system.with_timeout(d).send_and_recv(...)) but
  the rest of the API uses plain methods, so a single builder would have
  been an outlier. Stuck with the existing companion-method pattern
  (send_without_tx_cache, send_broadcast_without_tx_cache, etc.).

  Test plan

  - [x] cargo test --lib (default) — new test
  test_send_and_recv_with_timeout_fires registers a slow actor
  whose handler sleeps 5 s, calls with a 100 ms deadline, and
  asserts both that the result is Err(ActorError::Timeout(100ms))
  and that the call returned within 1 s
  - [x] cargo test --features multi-node
  - [x] cargo test --no-default-features --features unbounded-channel
  - [x] cargo test --no-default-features --features "unbounded-channel multi-node"
  - [x] Reproduce the original hang scenario against a live xanq broker:
  send_and_recv_with_timeout against a peer that's killed
  mid-flight returns within the deadline (the bug that motivated
  this PR)